### PR TITLE
Remove SSL Warning problem

### DIFF
--- a/src/MPRestClient.php
+++ b/src/MPRestClient.php
@@ -20,6 +20,9 @@ class MPRestClient {
         curl_setopt($connect, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($connect, CURLOPT_CUSTOMREQUEST, $method);
         curl_setopt($connect, CURLOPT_HTTPHEADER, array("Accept: application/json", "Content-Type: " . $content_type));
+        
+        curl_setopt($connect, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($connect, CURLOPT_SSL_VERIFYPEER, 0);
 
         return $connect;
     }


### PR DESCRIPTION
Message: SSL certificate problem: unable to get local issuer certificate
Ref:  https://yikesplugins.com/support/knowledge-base/i-receive-the-error-ssl-certificate-problem-unable-to-get-local-issuer-certificate-why/

Workarround:
Adding this lines in the get_connect function in order to bypass the ssl warning
        curl_setopt($connect, CURLOPT_SSL_VERIFYHOST, 0);
        curl_setopt($connect, CURLOPT_SSL_VERIFYPEER, 0);
